### PR TITLE
releasetools: do not remove dynamic partitions in system-only builds

### DIFF
--- a/tools/releasetools/common.py
+++ b/tools/releasetools/common.py
@@ -3609,10 +3609,11 @@ class DynamicGroupUpdate(object):
 
 class DynamicPartitionsDifference(object):
   def __init__(self, info_dict, block_diffs, progress_dict=None,
-               source_info_dict=None):
+               source_info_dict=None, build_without_vendor=False):
     if progress_dict is None:
       progress_dict = {}
 
+    self._build_without_vendor = build_without_vendor
     self._remove_all_before_apply = False
     if source_info_dict is None:
       self._remove_all_before_apply = True
@@ -3736,6 +3737,17 @@ class DynamicPartitionsDifference(object):
 
     def comment(line):
       self._op_list.append("# %s" % line)
+
+    if self._build_without_vendor:
+      comment('System-only build, keep original vendor partition')
+      # When building without vendor, we do not want to override
+      # any partition already existing. In this case, we can only
+      # resize, but not remove / create / re-create any other
+      # partition.
+      for p, u in self._partition_updates.items():
+        comment('Resize partition %s to %s' % (p, u.tgt_size))
+        append('resize %s %s' % (p, u.tgt_size))
+      return
 
     if self._remove_all_before_apply:
       comment('Remove all existing dynamic partitions and groups before '

--- a/tools/releasetools/non_ab_ota.py
+++ b/tools/releasetools/non_ab_ota.py
@@ -228,7 +228,8 @@ else if get_stage("%(bcb_dev)s") == "3/3" then
     dynamic_partitions_diff = common.DynamicPartitionsDifference(
         info_dict=OPTIONS.info_dict,
         block_diffs=block_diff_dict.values(),
-        progress_dict=progress_dict)
+        progress_dict=progress_dict,
+        build_without_vendor=(not HasPartition(input_zip, "vendor")))
     dynamic_partitions_diff.WriteScript(script, output_zip,
                                         write_verify_script=OPTIONS.verify)
   else:


### PR DESCRIPTION
* Before this commit, the generated `dynamic_partitions_op_list` in
  FullOTA packages always tries to remove all partitions and recreate
  them upon flashing. This makes it impossible to have a system-only
  "FullOTA" because vendor partition(s) are always removed.

* This commit detects if a build is vendor-less and disables every
  dynamic partition operation except `resize`, in order to keep the
  original content around after the flash. The change should not affect
  non-dynamic-partition or builds with vendor image included.

Change-Id: I0cded7f3b2958f35103d73d19b7fb5f292f6c17f
Signed-off-by: Jesse Chan <jc@lineageos.org>