### PR TITLE
releasetools: Properly handle map files

### DIFF
--- a/tools/releasetools/common.py
+++ b/tools/releasetools/common.py
@@ -2052,7 +2052,9 @@ def GetNonSparseImage(which, tmpdir, hashtree_info_generator=None):
 
   # The image and map files must have been created prior to calling
   # ota_from_target_files.py (since LMP).
-  assert os.path.exists(path) and os.path.exists(mappath)
+  assert os.path.exists(path)
+  if not os.path.exists(mappath):
+    mappath = None
 
   return images.FileImage(path, hashtree_info_generator=hashtree_info_generator)
 
@@ -2081,7 +2083,9 @@ def GetSparseImage(which, tmpdir, input_zip, allow_shared_blocks,
 
   # The image and map files must have been created prior to calling
   # ota_from_target_files.py (since LMP).
-  assert os.path.exists(path) and os.path.exists(mappath)
+  assert os.path.exists(path)
+  if not os.path.exists(mappath):
+    mappath = None
 
   # In ext4 filesystems, block 0 might be changed even being mounted R/O. We add
   # it to clobbered_blocks so that it will be written to the target


### PR DESCRIPTION
For squashfs or erofs, we currently don't have a system.map.
Instead of bailing out, set the mappath to None to fix build.

Change-Id: Ie04c060177f39d0e0cf711d28ea38b11dc40d3ab
Signed-off-by: alk3pInjection <webmaster@raspii.tech>